### PR TITLE
xquant: add write path scaffolding

### DIFF
--- a/src/llama-memory-xquant.cpp
+++ b/src/llama-memory-xquant.cpp
@@ -46,3 +46,24 @@ bool llama_memory_xquant::load_svd(const std::string & path, const llama_model &
     svd_loaded = true;
     return true;
 }
+
+ggml_tensor * llama_memory_xquant_context::write(ggml_context * ctx, ggml_tensor * x_cur, int32_t il) {
+    if (mem.layer_data.size() <= (size_t) il) {
+        mem.layer_data.resize(il + 1);
+    }
+    ggml_tensor * q = llama_xq_quantize(ctx, x_cur, 4);
+    mem.layer_data[il].push_back(q);
+    return q;
+}
+
+llama_memory_context_ptr llama_memory_xquant::init_batch(llama_batch_allocr &, uint32_t, bool) {
+    return std::make_unique<llama_memory_xquant_context>(*this);
+}
+
+llama_memory_context_ptr llama_memory_xquant::init_full() {
+    return std::make_unique<llama_memory_xquant_context>(*this);
+}
+
+llama_memory_context_ptr llama_memory_xquant::init_update(llama_context *, bool) {
+    return std::make_unique<llama_memory_xquant_context>(*this);
+}

--- a/src/llama-memory-xquant.h
+++ b/src/llama-memory-xquant.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "llama-memory.h"
+#include "ggml.h"
+#include "llama-xq-quant.h"
+#include "llama-batch.h"
 
 #include <cstdint>
 #include <string>
@@ -22,11 +25,13 @@ public:
     llama_memory_xquant(const llama_model & model) { (void) model; }
     ~llama_memory_xquant() override = default;
 
+    std::vector<std::vector<ggml_tensor *>> layer_data;
+
     bool load_svd(const std::string & path, const llama_model & model);
 
-    llama_memory_context_ptr init_batch(llama_batch_allocr &, uint32_t, bool) override { return nullptr; }
-    llama_memory_context_ptr init_full() override { return nullptr; }
-    llama_memory_context_ptr init_update(llama_context *, bool) override { return nullptr; }
+    llama_memory_context_ptr init_batch(llama_batch_allocr &, uint32_t, bool) override;
+    llama_memory_context_ptr init_full() override;
+    llama_memory_context_ptr init_update(llama_context *, bool) override;
 
     bool get_can_shift() const override { return false; }
 
@@ -52,5 +57,24 @@ private:
 class llama_memory_xquant_cl : public llama_memory_xquant {
 public:
     llama_memory_xquant_cl(const llama_model & model) : llama_memory_xquant(model) {}
+};
+
+
+class llama_memory_xquant_context : public llama_memory_context_i {
+public:
+    llama_memory_xquant_context(llama_memory_xquant & mem) : mem(mem) {}
+    ~llama_memory_xquant_context() override = default;
+
+    bool next() override { return processed ? false : (processed = true); }
+    bool apply() override { return true; }
+    const llama_ubatch & get_ubatch() const override { return dummy; }
+    llama_memory_status get_status() const override { return LLAMA_MEMORY_STATUS_SUCCESS; }
+
+    ggml_tensor * write(ggml_context * ctx, ggml_tensor * x_cur, int32_t il);
+
+private:
+    llama_memory_xquant & mem;
+    mutable llama_ubatch dummy{};
+    bool processed = false;
 };
 

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -6057,6 +6057,10 @@ struct llm_build_llama : public llm_graph_context {
                     model.layers[il].attn_norm, NULL,
                     LLM_NORM_RMS, il);
             cb(cur, "attn_norm", il);
+            if (cparams.xquant || cparams.xquant_cl) {
+                auto * xq_ctx = const_cast<llama_memory_xquant_context *>(static_cast<const llama_memory_xquant_context *>(mctx));
+                ggml_build_forward_expand(gf, xq_ctx->write(ctx0, cur, il));
+            }
 
             // self-attention
             {

--- a/src/llama-xq-quant.cpp
+++ b/src/llama-xq-quant.cpp
@@ -1,3 +1,3 @@
-#include "llama.h"
+#include "llama-xq-quant.h"
 
-// Placeholder for XQuant quantization helpers
+// Implementation provided in the header as inline helpers.

--- a/src/llama-xq-quant.h
+++ b/src/llama-xq-quant.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "ggml.h"
+#include "../ggml/src/ggml-quants.h"
+
+// map bit width to ggml quantization type
+inline ggml_type llama_xq_bits_to_type(int bits) {
+    switch (bits) {
+        case 8: return GGML_TYPE_Q8_0;
+        case 3: // fallthrough
+        case 4: return GGML_TYPE_Q4_0;
+        case 2: return GGML_TYPE_Q2_K;
+        default: return GGML_TYPE_Q4_0;
+    }
+}
+
+inline void llama_xq_quantize_row(const float * src, void * dst, int64_t k, int bits) {
+    switch (bits) {
+        case 8: quantize_row_q8_0_ref(src, (block_q8_0 *) dst, k); break;
+        case 3: // fallthrough
+        case 4: quantize_row_q4_0_ref(src, (block_q4_0 *) dst, k); break;
+        case 2: quantize_row_q2_K_ref(src, (block_q2_K *) dst, k); break;
+        default: quantize_row_q4_0_ref(src, (block_q4_0 *) dst, k); break;
+    }
+}
+
+inline ggml_tensor * llama_xq_quantize(ggml_context * ctx, ggml_tensor * src, int bits) {
+    ggml_type t = llama_xq_bits_to_type(bits);
+    ggml_tensor * dst = ggml_new_tensor(ctx, t, GGML_MAX_DIMS, src->ne);
+
+    const int64_t nrow = ggml_nrows(src);
+    const int64_t nper = src->ne[0];
+    const float * x = (const float *) src->data;
+    char * y = (char *) dst->data;
+    const size_t row_size = ggml_row_size(t, nper);
+
+    for (int64_t i = 0; i < nrow; ++i) {
+        llama_xq_quantize_row(x + i * nper, y + i * row_size, nper, bits);
+    }
+
+    return dst;
+}


### PR DESCRIPTION
## Summary
- add inline ggml-based helpers for XQuant packing
- implement provisional XQuant memory context and write method
- hook post-LN activations into XQuant memory in the LLaMA builder
- swap helper to use ggml's quantize_row implementations

## Testing
- `cmake -B build -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_SERVER=OFF -DLLAMA_BUILD_TOOLS=ON -DLLAMA_BUILD_XQ_TOOLS=ON`
- `cmake --build build --target llama xqsvd -j 2`


------
https://chatgpt.com/codex/tasks/task_e_68b623823bf0832ea9550d96efbc3447