### PR TITLE
Add XQuant validation tests, benchmark scripts, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ LLM inference in C/C++
 - Introducing GGUF-my-LoRA https://github.com/ggml-org/llama.cpp/discussions/10123
 - Hugging Face Inference Endpoints now support GGUF out of the box! https://github.com/ggml-org/llama.cpp/discussions/9669
 - Hugging Face GGUF editor: [discussion](https://github.com/ggml-org/llama.cpp/discussions/9268) | [tool](https://huggingface.co/spaces/CISCai/gguf-editor)
+- [Experimental XQuant KV replacement](./docs/xquant.md)
 
 ----
 

--- a/docs/xquant.md
+++ b/docs/xquant.md
@@ -1,0 +1,92 @@
+# XQuant: KV-Free Memory for llama.cpp
+
+XQuant replaces the traditional K/V cache with a compact stream of quantized post–layer-norm activations. K and V are rematerialized on demand, trading a small amount of extra compute for a large reduction in memory traffic.
+
+## Flags and Environment Variables
+
+| CLI Flag | Environment | Description |
+|----------|-------------|-------------|
+| `--xquant` | `LLAMA_XQUANT` | Enable XQuant (disables KV cache) |
+| `--xquant-cl` | `LLAMA_XQ_CL` | Cross‑layer delta mode; implies `--xquant` |
+| `--xq-bits <2|3|4|8>` | `LLAMA_XQ_BITS` | Bit width for stored activations (default 4) |
+| `--xq-group <int>` | `LLAMA_XQ_GROUP` | Quantization group size (default 128) |
+| `--xq-base-layers <int>` | `LLAMA_XQ_BASE_LAYERS` | Early layers pinned to 4‑bit (default 3) |
+| `--xq-gqa-svd` | `LLAMA_XQ_GQA_SVD` | Use latent caching for GQA via SVD |
+| `--xq-svd-rank <auto|int>` | `LLAMA_XQ_SVD_RANK` | Rank for SVD factors |
+| `--xq-svd-path <path>` | `LLAMA_XQ_SVD_PATH` | Location of `.xqsvd` blobs |
+
+XQuant flags are **mutually exclusive** with all `--kv-*` options. The model factory asserts that no KV cache is present whenever XQuant is active.
+
+## RoPE Timing
+
+When using XQuant, cached activations are stored **pre‑RoPE**. RoPE is applied only after K/V rematerialization, keeping the on‑disk representation agnostic to position.
+
+## SVD Workflow
+
+1. Run the `xqsvd` tool to generate factor files:
+   ```
+   ./xqsvd -m model.gguf -o model.xqsvd
+   ```
+2. Place the resulting `model.xqsvd` alongside the GGUF or pass `--xq-svd-path` when running inference.
+3. At load time, the runtime parses the `XQSV1` header, validates layer ranks and stores the factors for rematerialization.
+
+## Example Invocations
+
+```bash
+# Plain XQuant, 4‑bit
+./main -m model.gguf --xquant --xq-bits 4
+
+# Cross-layer deltas at 3‑bit
+./main -m model.gguf --xquant-cl --xq-bits 3
+
+# GQA + SVD latent caching
+./main -m model.gguf --xquant --xq-gqa-svd --xq-svd-path model.xqsvd
+```
+
+## Bench & PPL Scripts
+
+Helper scripts live under `tools/bench/`:
+
+- `xq-bench.sh` – runs `llama-bench` for baseline vs XQuant configurations and reports tokens/s and peak memory.
+- `xq-ppl.sh` – quick WikiText‑2 smoke test that compares perplexity deltas across modes.
+
+## Diagrams
+
+### Baseline KV Cache
+
+```mermaid
+flowchart LR
+  Tokens -->|Prefill| Graph
+  Graph --> ProjQKV[Q/K/V projections]
+  ProjQKV --> KVWrite[Write K/V to KV cache (pre-RoPE)]
+  loop Decode
+    NewTok --> Graph
+    Graph --> ProjQ[Q for new token]
+    KVRead[Read K/V for past tokens] --> RoPE
+    ProjQ --> RoPE[Apply RoPE to K,V,Q]
+    RoPE --> Attn[Attention] --> FFN --> Next
+  end
+```
+
+### XQuant Full Replacement
+
+```mermaid
+flowchart LR
+  Tokens -->|Prefill| Graph
+  Graph --> PostLN[Post-LayerNorm X (per layer)]
+  PostLN --> XQWrite[Quantize & Write: X / ΔX / Xk|Xv (latent)]
+  loop Decode
+    NewTok --> Graph
+    Graph --> PostLN2[Post-LayerNorm X (current layer)]
+    XQRead[Read X/ΔX/latent; reconstruct X̂ if CL]
+    XQRead --> Remat[Rematerialize: K = X̂·Wk, V = X̂·Wv (or small GEMMs for SVD)]
+    Remat --> RoPE[Apply RoPE to K,V,Q]
+    PostLN2 --> QProj[Q for new token]
+    QProj --> RoPE
+    RoPE --> Attn[Attention] --> FFN --> Next
+  end
+```
+
+## Notes
+
+XQuant remains experimental; accuracy and performance characteristics may vary across models and hardware.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -197,10 +197,19 @@ if (NOT LLAMA_SANITIZE_ADDRESS)
   llama_build_and_test(test-opt.cpp)
 endif()
 llama_build_and_test(test-gguf.cpp)
-llama_build_and_test(test-backend-ops.cpp)
+    llama_build_and_test(test-backend-ops.cpp)
 
-llama_build_and_test(test-model-load-cancel.cpp  LABEL "model")
-llama_build_and_test(test-autorelease.cpp        LABEL "model")
+    llama_build_and_test(test-model-load-cancel.cpp  LABEL "model")
+    llama_build_and_test(test-autorelease.cpp        LABEL "model")
+
+    llama_build_and_test(test-xq-quant.cpp)
+    llama_build_and_test(test-xq-svd.cpp)
+    llama_test_cmd(
+        ${CMAKE_CURRENT_SOURCE_DIR}/test-xq-no-kv.sh
+        NAME test-xq-no-kv
+        WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        ARGS $<TARGET_FILE:test-xq-quant>
+    )
 
 if (NOT GGML_BACKEND_DL)
     # these tests use the backends directly and cannot be built with dynamic loading

--- a/tests/test-xq-no-kv.sh
+++ b/tests/test-xq-no-kv.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TARGET=${1:?"binary to check"}
+if nm "$TARGET" | grep -q llama_kv_cache; then
+    echo "found llama_kv_cache symbol" >&2
+    exit 1
+fi

--- a/tests/test-xq-quant.cpp
+++ b/tests/test-xq-quant.cpp
@@ -1,0 +1,34 @@
+#include "../src/llama-xq-quant.h"
+#include "ggml.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+int main() {
+    ggml_init_params   params = { 16 * 1024 * 1024, NULL, false };
+    ggml_context *     ctx    = ggml_init(params);
+    const int          n      = 128;
+    std::vector<float> src(n);
+    for (int i = 0; i < n; ++i) {
+        src[i] = (float) i - 64.f;
+    }
+    ggml_tensor * t = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, n, 1);
+    std::memcpy(t->data, src.data(), n * sizeof(float));
+
+    ggml_tensor * q   = llama_xq_quantize(ctx, t, 4);
+    ggml_tensor * deq = ggml_cast(ctx, q, GGML_TYPE_F32);
+
+    float         max_err = 0.f;
+    const float * d       = (const float *) deq->data;
+    for (int i = 0; i < n; ++i) {
+        float err = std::fabs(src[i] - d[i]);
+        if (err > max_err) {
+            max_err = err;
+        }
+    }
+    ggml_free(ctx);
+    assert(max_err < 1.0f);
+    return 0;
+}

--- a/tests/test-xq-svd.cpp
+++ b/tests/test-xq-svd.cpp
@@ -1,0 +1,43 @@
+#include "../src/llama-memory-xquant.h"
+#include "../src/llama-model.h"
+
+#include <cassert>
+#include <cstdio>
+#include <fstream>
+
+struct llama_model_stub {
+    llm_type                 type = LLM_TYPE_UNKNOWN;
+    llm_arch                 arch = LLM_ARCH_UNKNOWN;
+    std::string              name;
+    llama_hparams            hparams;
+    std::vector<llama_layer> layers;
+};
+
+struct xq_svd_header {
+    char     magic[6];
+    uint32_t version;
+    uint32_t n_layer;
+    uint32_t d_model;
+};
+
+int main() {
+    llama_model_stub stub;
+    stub.hparams.n_layer = 1;
+    llama_memory_xquant mem(*reinterpret_cast<llama_model *>(&stub));
+
+    const char    path[] = "tmp.xqsvd";
+    std::ofstream fout(path, std::ios::binary);
+    xq_svd_header hdr = {
+        { 'X', 'Q', 'S', 'V', '1', '\0' },
+        1, 1, 0
+    };
+    fout.write(reinterpret_cast<char *>(&hdr), sizeof(hdr));
+    uint32_t rk = 8, rv = 8;
+    fout.write(reinterpret_cast<char *>(&rk), sizeof(rk));
+    fout.write(reinterpret_cast<char *>(&rv), sizeof(rv));
+    fout.close();
+
+    bool ok = mem.load_svd(path, *reinterpret_cast<llama_model *>(&stub));
+    std::remove(path);
+    return ok ? 0 : 1;
+}

--- a/tools/bench/xq-bench.sh
+++ b/tools/bench/xq-bench.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Microbenchmark helper for XQuant
+# Usage: ./xq-bench.sh <model.gguf>
+
+set -euo pipefail
+MODEL=${1:?"model path required"}
+LLAMA_BENCH_DIR="$(dirname "$0")/../llama-bench"
+BIN="${LLAMA_BENCH_DIR}/llama-bench"
+
+if [ ! -x "$BIN" ]; then
+    echo "llama-bench binary not found at $BIN" >&2
+    exit 1
+fi
+
+run_case() {
+    local NAME=$1; shift
+    echo "===== $NAME ====="
+    "$BIN" -m "$MODEL" "$@"
+    echo
+}
+
+run_case baseline ""
+run_case xquant4 --xquant --xq-bits 4
+run_case xquant-cl3 --xquant-cl --xq-bits 3

--- a/tools/bench/xq-ppl.sh
+++ b/tools/bench/xq-ppl.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Perplexity smoke test for XQuant using WikiText-2
+# Usage: ./xq-ppl.sh <model.gguf> <wikitext-2.txt>
+
+set -euo pipefail
+MODEL=${1:?"model path required"}
+DATA=${2:?"dataset required"}
+PERP_DIR="$(dirname "$0")/../perplexity"
+BIN="${PERP_DIR}/perplexity"
+
+if [ ! -x "$BIN" ]; then
+    echo "perplexity binary not found at $BIN" >&2
+    exit 1
+fi
+
+run_case() {
+    local NAME=$1; shift
+    echo "===== $NAME ====="
+    "$BIN" -m "$MODEL" -f "$DATA" "$@"
+    echo
+}
+
+run_case baseline ""
+run_case xquant4 --xquant --xq-bits 4
+run_case xquant-cl3 --xquant-cl --xq-bits 3


### PR DESCRIPTION
## Summary
- document XQuant usage, flags, and SVD workflow
- add unit tests for XQuant quantization and SVD loader, plus static guard against KV symbols
- provide helper bench and perplexity scripts for XQuant performance checks

## Testing
- `cmake -B build -DLLAMA_BUILD_TESTS=ON -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_SERVER=OFF -DLLAMA_BUILD_TOOLS=ON -DLLAMA_BUILD_XQ_TOOLS=ON`
- `cmake --build build --target test-xq-quant test-xq-svd -j 2`
- `ctest --test-dir build -R test-xq -V`

------
https://chatgpt.com/codex/tasks/task_e_68b62d1ffd5c832ebd28d591343eaa73