### PR TITLE
Handle errors in XQuant scripts

### DIFF
--- a/tools/bench/xq-bench.sh
+++ b/tools/bench/xq-bench.sh
@@ -25,7 +25,9 @@ fi
 run_case() {
     local NAME=$1; shift
     echo "===== $NAME ====="
-    "$BIN" -m "$MODEL" "$@"
+    if ! "$BIN" -m "$MODEL" "$@"; then
+        echo "benchmark failed for $NAME" >&2
+    fi
     echo
 }
 

--- a/tools/bench/xq-ppl.sh
+++ b/tools/bench/xq-ppl.sh
@@ -20,7 +20,9 @@ fi
 run_case() {
     local NAME=$1; shift
     echo "===== $NAME ====="
-    "$BIN" -m "$MODEL" -f "$DATA" "$@"
+    if ! "$BIN" -m "$MODEL" -f "$DATA" "$@"; then
+        echo "perplexity run failed for $NAME" >&2
+    fi
     echo
 }
 


### PR DESCRIPTION
## Summary
- Avoid aborting xq-bench.sh when a benchmark run fails
- Do the same for xq-ppl.sh so perplexity runs continue after failure

## Testing
- `bash -n tools/bench/xq-bench.sh`
- `bash -n tools/bench/xq-ppl.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b63cc3da30832e9ef0569bf1d79675