### PR TITLE
Fix XQuant segmentation fault during quantization

### DIFF
--- a/src/llama-xq-quant.h
+++ b/src/llama-xq-quant.h
@@ -1,42 +1,29 @@
 #pragma once
 
 #include "ggml.h"
-#include "../ggml/src/ggml-quants.h"
 
 // map bit width to ggml quantization type
 inline ggml_type llama_xq_bits_to_type(int bits) {
     switch (bits) {
-        case 8: return GGML_TYPE_Q8_0;
-        case 3: // fallthrough
-        case 4: return GGML_TYPE_Q4_0;
-        case 2: return GGML_TYPE_Q2_K;
-        default: return GGML_TYPE_Q4_0;
+        case 8:
+            return GGML_TYPE_Q8_0;
+        case 3:  // fallthrough
+        case 4:
+            return GGML_TYPE_Q4_0;
+        case 2:
+            return GGML_TYPE_Q2_K;
+        default:
+            return GGML_TYPE_Q4_0;
     }
 }
 
-inline void llama_xq_quantize_row(const float * src, void * dst, int64_t k, int bits) {
-    switch (bits) {
-        case 8: quantize_row_q8_0_ref(src, (block_q8_0 *) dst, k); break;
-        case 3: // fallthrough
-        case 4: quantize_row_q4_0_ref(src, (block_q4_0 *) dst, k); break;
-        case 2: quantize_row_q2_K_ref(src, (block_q2_K *) dst, k); break;
-        default: quantize_row_q4_0_ref(src, (block_q4_0 *) dst, k); break;
-    }
-}
-
+// runtime quantization helper
+// NOTE: using ggml_cast ensures that quantization happens as part of the
+// compute graph instead of during graph construction. The previous
+// implementation invoked the low-level quantize_row_* routines immediately
+// which attempted to read from `src->data` before it was populated, leading to
+// segmentation faults when XQuant was enabled.
 inline ggml_tensor * llama_xq_quantize(ggml_context * ctx, ggml_tensor * src, int bits) {
     ggml_type t = llama_xq_bits_to_type(bits);
-    ggml_tensor * dst = ggml_new_tensor(ctx, t, GGML_MAX_DIMS, src->ne);
-
-    const int64_t nrow = ggml_nrows(src);
-    const int64_t nper = src->ne[0];
-    const float * x = (const float *) src->data;
-    char * y = (char *) dst->data;
-    const size_t row_size = ggml_row_size(t, nper);
-
-    for (int64_t i = 0; i < nrow; ++i) {
-        llama_xq_quantize_row(x + i * nper, y + i * row_size, nper, bits);
-    }
-
-    return dst;
+    return ggml_cast(ctx, src, t);
 }


### PR DESCRIPTION
## Summary
- replace manual quantization routine with ggml_cast so XQuant quantizes at runtime
- add comment documenting that previous approach read uninitialized tensors and segfaulted

## Testing
- `cmake -B build -DLLAMA_BUILD_TESTS=ON -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_SERVER=OFF -DLLAMA_BUILD_TOOLS=ON -DLLAMA_BUILD_XQ_TOOLS=ON`
- `cmake --build build --target test-xq-quant test-xq-svd -j 2`
- `ctest --test-dir build -R test-xq -V`


------
https://chatgpt.com/codex/tasks/task_e_68b63f6a6e78832ea4784bc6cafd9cd3