### PR TITLE
Track token counts for XQuant pending and cached blocks

### DIFF
--- a/src/llama-memory-xquant.h
+++ b/src/llama-memory-xquant.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "llama-memory.h"
 #include "ggml.h"
-#include "llama-xq-quant.h"
 #include "llama-batch.h"
+#include "llama-memory.h"
+#include "llama-xq-quant.h"
 
 #include <cstdint>
 #include <string>
@@ -18,14 +18,15 @@ struct llama_xq_svd_layer {
 };
 
 class llama_memory_xquant : public llama_memory_i {
-public:
+  public:
     llama_memory_xquant(const llama_model & model) : model(model) {}
+
     ~llama_memory_xquant() override = default;
 
     struct xq_block {
-        ggml_type type;
-        int64_t   ne0;
-        int64_t   ne1;
+        ggml_type            type;
+        int64_t              ne0;
+        int64_t              ne1;  // tokens (logical)
         std::vector<uint8_t> data;
     };
 
@@ -42,57 +43,66 @@ public:
     void clear(bool) override {}
 
     bool seq_rm(llama_seq_id, llama_pos, llama_pos) override { return true; }
+
     void seq_cp(llama_seq_id, llama_seq_id, llama_pos, llama_pos) override {}
+
     void seq_keep(llama_seq_id) override {}
+
     void seq_add(llama_seq_id, llama_pos, llama_pos, llama_pos) override {}
+
     void seq_div(llama_seq_id, llama_pos, llama_pos, int) override {}
 
     llama_pos seq_pos_min(llama_seq_id) const override { return 0; }
+
     llama_pos seq_pos_max(llama_seq_id) const override { return 0; }
 
     void state_write(llama_io_write_i &, llama_seq_id, llama_state_seq_flags) const override {}
+
     void state_read(llama_io_read_i &, llama_seq_id, llama_state_seq_flags) override {}
 
-private:
+  private:
     friend class llama_memory_xquant_context;
 
     const llama_model & model;
 
-    bool svd_loaded = false;
+    bool                            svd_loaded = false;
     std::vector<llama_xq_svd_layer> svd_layers;
 };
 
 class llama_memory_xquant_cl : public llama_memory_xquant {
-public:
+  public:
     llama_memory_xquant_cl(const llama_model & model) : llama_memory_xquant(model) {}
 };
 
-
 class llama_memory_xquant_context : public llama_memory_context_i {
-public:
+  public:
     struct pending_write {
-        int32_t     il;
+        int32_t       il;
         ggml_tensor * q;
+        int64_t       n_tokens;  // logical token count for this write
     };
 
     llama_memory_xquant_context(llama_memory_xquant & mem) : mem(mem) {}
+
     ~llama_memory_xquant_context() override = default;
 
     bool next() override { return processed ? false : (processed = true); }
+
     bool apply() override;
+
     const llama_ubatch & get_ubatch() const override { return dummy; }
+
     llama_memory_status get_status() const override { return LLAMA_MEMORY_STATUS_SUCCESS; }
 
     ggml_tensor * write(ggml_context * ctx, ggml_tensor * x_cur, int32_t il);
 
-    uint32_t get_n_kv() const;
+    uint32_t      get_n_kv() const;
     ggml_tensor * get_k(ggml_context * ctx, int32_t il);
     ggml_tensor * get_v(ggml_context * ctx, int32_t il);
 
-private:
-    llama_memory_xquant & mem;
+  private:
+    llama_memory_xquant &      mem;
     std::vector<pending_write> pending;
-    mutable llama_ubatch dummy{};
-    bool processed = false;
+    mutable llama_ubatch       dummy{};
+    bool                       processed = false;
 };
-

--- a/tests/test-xq-reshape.cpp
+++ b/tests/test-xq-reshape.cpp
@@ -1,8 +1,8 @@
-#include "ggml.h"
 #include "../src/llama-memory-xquant.h"
+#include "ggml.h"
 
-#include <vector>
 #include <cstring>
+#include <vector>
 
 static ggml_tensor * normalize(ggml_context * ctx, ggml_tensor * t, int64_t d_model) {
     int64_t elems = ggml_nelements(t);
@@ -14,16 +14,17 @@ static ggml_tensor * normalize(ggml_context * ctx, ggml_tensor * t, int64_t d_mo
     return t;
 }
 
-static ggml_tensor * xq_dequant_concat_test(ggml_context * ctx,
-        const std::vector<llama_memory_xquant::xq_block> & qs,
-        const std::vector<llama_memory_xquant_context::pending_write> & pending,
-        int32_t il, int64_t d_model) {
+static ggml_tensor * xq_dequant_concat_test(ggml_context *                                                  ctx,
+                                            const std::vector<llama_memory_xquant::xq_block> &              qs,
+                                            const std::vector<llama_memory_xquant_context::pending_write> & pending,
+                                            int32_t                                                         il,
+                                            int64_t                                                         d_model) {
     ggml_tensor * cur = nullptr;
     for (const auto & blk : qs) {
         ggml_tensor * qt = ggml_new_tensor_2d(ctx, blk.type, d_model, blk.ne1);
         memcpy(qt->data, blk.data.data(), blk.data.size());
         ggml_tensor * deq = ggml_cast(ctx, qt, GGML_TYPE_F32);
-        deq = normalize(ctx, deq, d_model);
+        deq               = normalize(ctx, deq, d_model);
         if (!cur) {
             cur = deq;
         } else {
@@ -32,9 +33,11 @@ static ggml_tensor * xq_dequant_concat_test(ggml_context * ctx,
         }
     }
     for (const auto & pw : pending) {
-        if (pw.il != il) continue;
+        if (pw.il != il) {
+            continue;
+        }
         ggml_tensor * deq = ggml_cast(ctx, pw.q, GGML_TYPE_F32);
-        deq = normalize(ctx, deq, d_model);
+        deq               = normalize(ctx, deq, d_model);
         if (!cur) {
             cur = deq;
         } else {
@@ -46,40 +49,42 @@ static ggml_tensor * xq_dequant_concat_test(ggml_context * ctx,
 }
 
 int main() {
-    ggml_init_params ip = { 16u * 1024u * 1024u, nullptr, false };
-    ggml_context * ctx = ggml_init(ip);
-    if (!ctx) return 1;
+    ggml_init_params ip  = { 16u * 1024u * 1024u, nullptr, false };
+    ggml_context *   ctx = ggml_init(ip);
+    if (!ctx) {
+        return 1;
+    }
 
     const int64_t d_model = 8;
 
     // 1. Concat Normalization
     {
-        ggml_tensor * A = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, d_model, 3);
-        ggml_tensor * B = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, d_model, 5);
+        ggml_tensor * A   = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, d_model, 3);
+        ggml_tensor * B   = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, d_model, 5);
         ggml_tensor * cur = ggml_concat(ctx, A, B, 1);
-        cur = normalize(ctx, cur, d_model);
+        cur               = normalize(ctx, cur, d_model);
         GGML_ASSERT(cur->ne[0] == d_model);
         GGML_ASSERT(cur->ne[1] == 8);
     }
 
     // 2. Pending + Cached Mix
     {
-        using xq_block = llama_memory_xquant::xq_block;
+        using xq_block      = llama_memory_xquant::xq_block;
         using pending_write = llama_memory_xquant_context::pending_write;
-        std::vector<xq_block> qs;
+        std::vector<xq_block>      qs;
         std::vector<pending_write> pend;
-        for (int n : {2,4}) {
+        for (int n : { 2, 4 }) {
             xq_block blk;
             blk.type = GGML_TYPE_F32;
-            blk.ne0 = d_model;
-            blk.ne1 = n;
-            blk.data.resize((size_t)d_model * n * sizeof(float));
+            blk.ne0  = d_model;
+            blk.ne1  = n;
+            blk.data.resize((size_t) d_model * n * sizeof(float));
             qs.push_back(std::move(blk));
         }
         ggml_tensor * q_pending = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, d_model, 3);
-        pend.push_back({0, q_pending});
+        pend.push_back({ 0, q_pending, 3 });
         ggml_tensor * cur = xq_dequant_concat_test(ctx, qs, pend, 0, d_model);
-        cur = normalize(ctx, cur, d_model);
+        cur               = normalize(ctx, cur, d_model);
         GGML_ASSERT(cur->ne[0] == d_model);
         GGML_ASSERT(cur->ne[1] == 9);
     }
@@ -87,19 +92,19 @@ int main() {
     // 3. Idempotence
     {
         ggml_tensor * T = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, d_model, 7);
-        T = normalize(ctx, T, d_model);
-        int64_t ne0 = T->ne[0];
-        int64_t ne1 = T->ne[1];
-        T = normalize(ctx, T, d_model);
+        T               = normalize(ctx, T, d_model);
+        int64_t ne0     = T->ne[0];
+        int64_t ne1     = T->ne[1];
+        T               = normalize(ctx, T, d_model);
         GGML_ASSERT(T->ne[0] == ne0 && T->ne[1] == ne1);
     }
 
     // 4. Matmul Precondition
     {
-        ggml_tensor * wk = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, d_model, d_model);
-        ggml_tensor * A = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, d_model, 5);
-        ggml_tensor * cur = ggml_concat(ctx, A, A, 1);
-        cur = normalize(ctx, cur, d_model);
+        ggml_tensor * wk   = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, d_model, d_model);
+        ggml_tensor * A    = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, d_model, 5);
+        ggml_tensor * cur  = ggml_concat(ctx, A, A, 1);
+        cur                = normalize(ctx, cur, d_model);
         ggml_tensor * prod = ggml_mul_mat(ctx, wk, cur);
         GGML_ASSERT(prod->ne[0] == d_model);
         GGML_ASSERT(prod->ne[1] == 10);


### PR DESCRIPTION
## Summary
- track logical token count for XQuant writes and cached blocks
- avoid row-size asserts by trusting stored token counts when applying, counting KV pairs, and dequantizing
- update xq reshape test for new pending_write format

## Testing
- `cmake -B build -DLLAMA_BUILD_TESTS=ON`
- `cmake --build build --target test-xq-reshape`
- `ctest --test-dir build --output-on-failure -R test-xq-reshape`


------
https://chatgpt.com/codex/tasks/task_e_68b661c9e5c8832e92d7490db5cc500f