### PR TITLE
Thread xquant bit width through memory context

### DIFF
--- a/docs/xquant.md
+++ b/docs/xquant.md
@@ -17,6 +17,16 @@ XQuant replaces the traditional K/V cache with a compact stream of quantized pos
 
 XQuant flags are **mutually exclusive** with all `--kv-*` options. The model factory asserts that no KV cache is present whenever XQuant is active.
 
+### Bit Width Mapping
+
+The `--xq-bits` flag controls the ggml tensor type used to store activations:
+
+- `2` → `Q2_K`
+- `3` or `4` → `Q4_0`
+- `8` → `Q8_0`
+
+Values other than those listed fall back to `Q4_0`.
+
 ## RoPE Timing
 
 When using XQuant, cached activations are stored **pre‑RoPE**. RoPE is applied only after K/V rematerialization, keeping the on‑disk representation agnostic to position.

--- a/src/llama-memory-xquant.cpp
+++ b/src/llama-memory-xquant.cpp
@@ -48,7 +48,7 @@ bool llama_memory_xquant::load_svd(const std::string & path, const llama_model &
     return true;
 }
 
-ggml_tensor * llama_memory_xquant_context::write(ggml_context * ctx, ggml_tensor * x_cur, int32_t il) {
+ggml_tensor * llama_memory_xquant_context::write(ggml_context * ctx, ggml_tensor * x_cur, int32_t il, int32_t bits) {
     if (mem.layer_data.size() <= static_cast<size_t>(il)) {
         mem.layer_data.resize(il + 1);
     }
@@ -71,7 +71,7 @@ ggml_tensor * llama_memory_xquant_context::write(ggml_context * ctx, ggml_tensor
 
     const int64_t n_tokens = x_cur->ne[1];
 
-    ggml_tensor * q = llama_xq_quantize(ctx, x_cur, 4);
+    ggml_tensor * q = llama_xq_quantize(ctx, x_cur, bits);
     LLAMA_LOG_DEBUG("xq_quantize: qtype=%d ne=(%lld,%lld,%lld,%lld) nbytes=%zu tokens=%lld\n",
                     (int) q->type,
                     (long long) q->ne[0],

--- a/src/llama-memory-xquant.h
+++ b/src/llama-memory-xquant.h
@@ -94,7 +94,7 @@ class llama_memory_xquant_context : public llama_memory_context_i {
 
     llama_memory_status get_status() const override { return LLAMA_MEMORY_STATUS_SUCCESS; }
 
-    ggml_tensor * write(ggml_context * ctx, ggml_tensor * x_cur, int32_t il);
+    ggml_tensor * write(ggml_context * ctx, ggml_tensor * x_cur, int32_t il, int32_t bits);
 
     uint32_t      get_n_kv() const;
     ggml_tensor * get_k(ggml_context * ctx, int32_t il);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -6059,7 +6059,7 @@ struct llm_build_llama : public llm_graph_context {
             cb(cur, "attn_norm", il);
             if (cparams.xquant || cparams.xquant_cl) {
                 auto * xq_ctx = const_cast<llama_memory_xquant_context *>(static_cast<const llama_memory_xquant_context *>(mctx));
-                ggml_build_forward_expand(gf, xq_ctx->write(ctx0, cur, il));
+                ggml_build_forward_expand(gf, xq_ctx->write(ctx0, cur, il, cparams.xq_bits));
             }
 
             // self-attention

--- a/tests/test-xq-mem.cpp
+++ b/tests/test-xq-mem.cpp
@@ -69,7 +69,9 @@ int main() {
     ggml_tensor * Xt = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, d, T);
     memcpy(Xt->data, X.data(), X.size() * sizeof(float));
 
-    xq_ctx->write(ctx, Xt, 0);
+    int bits = 4;
+    ggml_tensor * q = xq_ctx->write(ctx, Xt, 0, bits);
+    GGML_ASSERT(q->type == llama_xq_bits_to_type(bits));
     ggml_tensor * K = xq_ctx->get_k(ctx, 0);
     ggml_cgraph * gf = ggml_new_graph(ctx);
     ggml_build_forward_expand(gf, K);

--- a/tests/test-xq-quant.cpp
+++ b/tests/test-xq-quant.cpp
@@ -17,8 +17,13 @@ int main() {
     ggml_tensor * t = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, n, 1);
     std::memcpy(t->data, src.data(), n * sizeof(float));
 
-    ggml_tensor * q   = llama_xq_quantize(ctx, t, 4);
-    ggml_tensor * deq = ggml_cast(ctx, q, GGML_TYPE_F32);
+    for (int bits : {2, 4, 8}) {
+        ggml_tensor * q = llama_xq_quantize(ctx, t, bits);
+        GGML_ASSERT(q->type == llama_xq_bits_to_type(bits));
+    }
+
+    ggml_tensor * q4   = llama_xq_quantize(ctx, t, 4);
+    ggml_tensor * deq = ggml_cast(ctx, q4, GGML_TYPE_F32);
 
     float         max_err = 0.f;
     const float * d       = (const float *) deq->data;


### PR DESCRIPTION
## Summary
- allow XQuant memory writes to honor the configured bit width
- pass the bit width to `llama_xq_quantize`
- test and document that `--xq-bits` selects the quantized tensor type

## Testing
- `cmake --build build --target test-xq-quant test-xq-mem`
- `./build/bin/test-xq-quant`
- `./build/bin/test-xq-mem` *(fails: LLAMA_TEST_MODEL not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b69b4070f0832ea68369301a172348