### PR TITLE
Fix token count for pending writes

### DIFF
--- a/src/llama-memory-xquant.h
+++ b/src/llama-memory-xquant.h
@@ -23,6 +23,8 @@ class llama_memory_xquant : public llama_memory_i {
 
     ~llama_memory_xquant() override = default;
 
+    int64_t get_d_model() const;
+
     struct xq_block {
         ggml_type            type;
         int64_t              ne0;


### PR DESCRIPTION
## Summary
- ensure pending quantized writes contribute only whole-token rows
- expose embedding dimension via `get_d_model()`

## Testing
- `cmake --build build -j`
- `cd build && ctest --output-on-failure -j2` *(fails: test-thread-safety, test-arg-parser, test-eval-callback; model download failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a0e81730832e80ea68fc7d5cea7c