### PR TITLE
docs: add AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS
+
+This file provides guidance for contributors and automation working in this repository.
+
+## Testing
+- Build the project with `cmake -B build`.
+- Compile with `cmake --build build`.
+- Run the test suite with `ctest --test-dir build`.
+- If only Python code is touched, run `pytest` instead of the CMake steps.
+
+## Code Style
+- Follow the guidelines in [CONTRIBUTING.md](CONTRIBUTING.md).
+- Format C and C++ sources with `clang-format` (version 15+).
+- Use four spaces for indentation and keep lines free of trailing whitespace.
+
+## Pull Requests
+- Keep changes focused and well described.
+- Document any new command-line options or APIs.
+- Include test results in the PR description.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ This file provides guidance for contributors and automation working in this repo
 - Build the project with `cmake -B build`.
 - Compile with `cmake --build build`.
 - Run the test suite with `ctest --test-dir build`.
+- Rerun tests if failed with `ctest --test-dir build --output-on-failure --rerun-failed` to figure out why tests failed.
 - If only Python code is touched, run `pytest` instead of the CMake steps.
 
 ## Code Style


### PR DESCRIPTION
## Summary
- add AGENTS.md with testing, style, and PR guidelines for contributors

## Testing
- `cmake -B build`
- `cmake --build build -j 2`
- `ctest --test-dir build` *(fails: Errors while running CTest)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a39d1d48832e953d202ab71e2711