### PR TITLE
fix xquant kv length mismatch

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -6079,9 +6079,9 @@ struct llm_build_llama : public llm_graph_context {
 
                     Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head, n_tokens);
 
-                    ggml_tensor * K = xq_ctx->get_k(ctx0, il);
-                    ggml_tensor * V = xq_ctx->get_v(ctx0, il);
-                    uint32_t n_kv = xq_ctx->get_n_kv();
+                    ggml_tensor * K     = xq_ctx->get_k(ctx0, il);
+                    ggml_tensor * V     = xq_ctx->get_v(ctx0, il);
+                    uint32_t      n_kv  = K ? K->ne[2] : 0;
                     ggml_tensor * k_pos = ggml_cast(ctx0, ggml_arange(ctx0, 0.0f, (float) n_kv, 1.0f), GGML_TYPE_I32);
 
                     Qcur = ggml_rope_ext(


### PR DESCRIPTION
## Summary
- derive KV length from computed K tensor instead of cached counter to avoid dimension mismatches during RoPE

## Testing
- `cmake --build build`
- `ctest --test-dir build` *(fails: Failure when receiving data from the peer)*
- `ctest --test-dir build --output-on-failure --rerun-failed` *(fails: Failure when receiving data from the peer)*

------
https://chatgpt.com/codex/tasks/task_e_68b73d623d7c832eb87a916f50faff73