### PR TITLE
fix xquant kv length mismatch

### DIFF
--- a/src/llama-memory-xquant.cpp
+++ b/src/llama-memory-xquant.cpp
@@ -168,15 +168,14 @@ static uint32_t count_tokens_for_layer(const llama_memory_xquant &              
         if (pw.il != il) {
             continue;
         }
-
-        const size_t row_b = ggml_row_size(pw.q->type, d_model);
-        const size_t bytes = ggml_nbytes(pw.q);
-        if (row_b == 0 || bytes % row_b != 0) {
+        int64_t elems = ggml_nelements(pw.q);
+        elems -= elems % d_model;
+        if (elems == 0) {
             continue;
         }
 
-        const size_t tokens_bytes = bytes / row_b;
-        n += (uint32_t) std::min<size_t>((size_t) pw.n_tokens, tokens_bytes);
+        const uint32_t tokens = (uint32_t) (elems / d_model);
+        n += std::min<uint32_t>(tokens, pw.n_tokens);
     }
 
     return n;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -6079,9 +6079,9 @@ struct llm_build_llama : public llm_graph_context {
 
                     Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head, n_tokens);
 
-                    ggml_tensor * K = xq_ctx->get_k(ctx0, il);
-                    ggml_tensor * V = xq_ctx->get_v(ctx0, il);
-                    uint32_t n_kv = xq_ctx->get_n_kv();
+                    ggml_tensor * K     = xq_ctx->get_k(ctx0, il);
+                    ggml_tensor * V     = xq_ctx->get_v(ctx0, il);
+                    uint32_t      n_kv  = K ? K->ne[2] : 0;
                     ggml_tensor * k_pos = ggml_cast(ctx0, ggml_arange(ctx0, 0.0f, (float) n_kv, 1.0f), GGML_TYPE_I32);
 
                     Qcur = ggml_rope_ext(


### PR DESCRIPTION
## Summary
- derive KV length from computed K tensor instead of cached counter to avoid dimension mismatches during RoPE
- trim token counts for pending xquant writes to multiples of the model width to keep KV lengths consistent

## Testing
- `cmake -B build`
- `cmake --build build` *(fails: terminated during long compilation)*
- `ctest --test-dir build` *(fails: missing test executables)*
- `ctest --test-dir build --output-on-failure --rerun-failed` *(fails: missing test executables)*

------
https://chatgpt.com/codex/tasks/task_e_68b73d623d7c832eb87a916f50faff73